### PR TITLE
Fix procedure to install prometheus-slurm-exporter on Ubuntu 22.04 OS…

### DIFF
--- a/aws-parallelcluster-monitoring/parallelcluster-setup/install-monitoring.sh
+++ b/aws-parallelcluster-monitoring/parallelcluster-setup/install-monitoring.sh
@@ -116,8 +116,10 @@ case "${cfn_node_type}" in
 		# More info here: https://github.com/vpenso/prometheus-slurm-exporter/blob/master/LICENSE
 		cd ${monitoring_home}
 		git clone --branch development https://github.com/vpenso/prometheus-slurm-exporter.git
+        export HOME=/root
+        git config --global --add safe.directory ${monitoring_home}/prometheus-slurm-exporter
 		cd prometheus-slurm-exporter
-                sed -i 's/NodeList,AllocMem,Memory,CPUsState,StateLong/NodeList: ,AllocMem: ,Memory: ,CPUsState: ,StateLong:/' node.go
+        sed -i 's/NodeList,AllocMem,Memory,CPUsState,StateLong/NodeList: ,AllocMem: ,Memory: ,CPUsState: ,StateLong:/' node.go
 		GOPATH=/root/go-modules-cache HOME=/root go mod download
 		GOPATH=/root/go-modules-cache HOME=/root go build
 		mv ${monitoring_home}/prometheus-slurm-exporter/prometheus-slurm-exporter /usr/bin/prometheus-slurm-exporter


### PR DESCRIPTION
…; fix indentation of sed command.

*Issue #, if available:* prometheus-slurm-exporter not running on Ubuntu 22.04 OS

*Description of changes:* the procedure need to export the HOME on new git version before the execution of the required git config command.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
